### PR TITLE
Add I9 macbook pro 2019 benchmarks for emacs 28

### DIFF
--- a/cpu/I9-9980HK-Macbook-pro-BigSur.org
+++ b/cpu/I9-9980HK-Macbook-pro-BigSur.org
@@ -1,0 +1,39 @@
+* Specs
+- CPU: I9-9980HK
+- OS: macOS BigSur
+- Emacs: 28
+- Benchmarks: 1.14
+
+* Notes
+
+#+begin_src shell
+  git clone https://github.com/jimeh/build-emacs-for-macos.git
+  cd build-emacs-for-macos
+  ./build-emacs-for-macos --no-xwidgets --native-full-aot -j 16 emacs-28.1
+#+end_src
+
+* Results
+
+  | test               | non-gc avg (s) | gc avg (s) | gcs avg | tot avg (s) | tot avg err (s) |
+  |--------------------+----------------+------------+---------+-------------+-----------------|
+  | bubble             |           1.48 |       0.31 |       1 |        1.79 |            0.05 |
+  | bubble-no-cons     |           2.41 |       0.00 |       0 |        2.41 |            0.13 |
+  | bytecomp           |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | dhrystone          |           3.13 |       0.00 |       0 |        3.13 |            0.17 |
+  | eieio              |           1.68 |       0.80 |       9 |        2.48 |            0.11 |
+  | fibn               |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | fibn-named-let     |           1.55 |       0.00 |       0 |        1.55 |            0.07 |
+  | fibn-rec           |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | fibn-tc            |           0.01 |       0.00 |       0 |        0.01 |            0.00 |
+  | flet               |           2.55 |       0.00 |       0 |        2.55 |            0.08 |
+  | inclist            |           1.93 |       0.00 |       0 |        1.93 |            0.06 |
+  | inclist-type-hints |           1.86 |       0.00 |       0 |        1.86 |            0.07 |
+  | listlen-tc         |           0.18 |       0.00 |       0 |        0.18 |            0.01 |
+  | map-closure        |           8.13 |       0.00 |       0 |        8.13 |            0.18 |
+  | nbody              |           1.90 |       0.61 |       1 |        2.50 |            0.09 |
+  | pack-unpack        |           0.44 |       0.18 |       2 |        0.61 |            0.01 |
+  | pack-unpack-old    |           0.61 |       0.35 |       4 |        0.97 |            0.02 |
+  | pcase              |           2.49 |       0.00 |       0 |        2.49 |            0.05 |
+  | pidigits           |          10.89 |       6.93 |      21 |       17.82 |            0.62 |
+  |--------------------+----------------+------------+---------+-------------+-----------------|
+  | total              |          41.24 |       9.18 |      38 |       50.42 |            0.72 |


### PR DESCRIPTION
`elb-smie.el` threw an error.

libgccjit.so: error: gcc_jit_context_new_call_through_ptr: too many arguments to fn_ptr: freloc->R706f696e742d6d696e_point_min_0 (got 2 args, expected 0)
Debugger entered--Lisp error: (native-ice \"gcc_jit_context_new_call_through_ptr: too many arg...\")
  comp--compile-ctxt-to-file(\"/Users/ckoneru/.emacs.d/eln-cache/28_1-2d3c4383/el...\")
  comp-compile-ctxt-to-file(\"/Users/ckoneru/.emacs.d/eln-cache/28_1-2d3c4383/el...\")
  comp-final1()
  load-with-code-conversion(\"/private/var/folders/m4/4cykvy6s2dl9fpspnb8k6frmhh...\" \"/private/var/folders/m4/4cykvy6s2dl9fpspnb8k6frmhh...\" nil t)
  command-line-1((\"-l\" \"/var/folders/m4/4cykvy6s2dl9fpspnb8k6frmhhjltb/T/e...\"))
  command-line()
  normal-top-level()