### PR TITLE
Add new Ryzen 5900x benchmark

### DIFF
--- a/cpu/amd-ryzen-5900x-cpbotha.org
+++ b/cpu/amd-ryzen-5900x-cpbotha.org
@@ -1,0 +1,53 @@
+* Specs
+
+- CPU: AMD Ryzen 5900X with 64GB DDR4-3600
+- OS: Ubuntu 20.04.5 LTS on WSL  0.67.6.0 on Windows 11 build 22622.601
+- GNU Emacs 29.0.50 (build 2, x86_64-pc-linux-gnu, GTK+ Version 3.24.20, cairo version 1.16.0) of 2022-09-11
+- Benchmarks: 1.14
+
+* Notes
+
+Using a heavily modified version of Mickey Petersen's docker setup, with =gcc-11
+libgccjit0 libgccjit-11-dev= installed from =ppa:ubuntu-toolchain-r/test=.
+
+#+BEGIN_SRC sh
+  ./autogen.sh \
+         && ./configure CFLAGS='-g3 -O2' \
+         --with-native-compilation \
+         --with-mailutils \
+         --without-gconf \
+         --without-gsettings
+
+  make clean && make -j 24 && make install
+
+  # later:
+  emacs -batch -l elisp-benchmarks.el -f elisp-benchmarks-run
+#+END_SRC
+
+* Results
+
+  | test               | non-gc avg (s) | gc avg (s) | gcs avg | tot avg (s) | tot avg err (s) |
+  |--------------------+----------------+------------+---------+-------------+-----------------|
+  | bubble             |           0.57 |       0.07 |       1 |        0.63 |            0.03 |
+  | bubble-no-cons     |           0.59 |       0.00 |       0 |        0.59 |            0.00 |
+  | bytecomp           |           0.85 |       0.19 |      12 |        1.04 |            0.02 |
+  | dhrystone          |           1.70 |       0.00 |       0 |        1.70 |            0.00 |
+  | eieio              |           0.75 |       0.09 |       6 |        0.85 |            0.00 |
+  | fibn               |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | fibn-named-let     |           1.02 |       0.00 |       0 |        1.02 |            0.00 |
+  | fibn-rec           |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | fibn-tc            |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | flet               |           0.97 |       0.00 |       0 |        0.97 |            0.00 |
+  | inclist            |           0.83 |       0.00 |       0 |        0.83 |            0.01 |
+  | inclist-type-hints |           0.79 |       0.00 |       0 |        0.79 |            0.01 |
+  | listlen-tc         |           0.10 |       0.00 |       0 |        0.10 |            0.00 |
+  | map-closure        |           3.12 |       0.00 |       0 |        3.12 |            0.00 |
+  | nbody              |           1.09 |       0.17 |       1 |        1.26 |            0.05 |
+  | pack-unpack        |           0.23 |       0.02 |       1 |        0.25 |            0.01 |
+  | pack-unpack-old    |           0.35 |       0.05 |       3 |        0.39 |            0.00 |
+  | pcase              |           1.41 |       0.00 |       0 |        1.41 |            0.01 |
+  | pidigits           |           3.04 |       0.66 |      16 |        3.70 |            0.00 |
+  | scroll             |           0.42 |       0.00 |       0 |        0.42 |            0.00 |
+  | smie               |           0.92 |       0.02 |       1 |        0.94 |            0.00 |
+  |--------------------+----------------+------------+---------+-------------+-----------------|
+  | total              |          18.74 |       1.26 |      41 |       20.00 |            0.07 |


### PR DESCRIPTION
Newer version of Emacs on a different 5900x system which altogether benches much faster than the existing measurement.
