### PR TITLE
add apple m4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ This is a repo of elisp-benchmarks with native compilation run on different CPUs
 ## High scores
 
 1. AMD Ryzen 7950X: 14.36s
-2. AMD Ryzen 5900X: 20s
-3. Intel i3 14100F: 20.87s
-4. Apple M3: 24.13s
-5. Intel i5 1350P: 25.23s
-6. AMD Ryzen 5700G: 25.51s
-7. Intel Core i9-11900K: 26.42s
-8. Apple M2: 28.94s
-9. Intel i7-1355U: 29.31s
-10. Apple M1: 40.37s
+2. Apple M4: 16.01s
+3. AMD Ryzen 5900X: 20s
+4. Intel i3 14100F: 20.87s
+5. Apple M3: 24.13s
+6. Intel i5 1350P: 25.23s
+7. AMD Ryzen 5700G: 25.51s
+8. Intel Core i9-11900K: 26.42s
+9. Apple M2: 28.94s
+10. Intel i7-1355U: 29.31s
 
 ## Submit your own
 

--- a/cpu/apple-m4.org
+++ b/cpu/apple-m4.org
@@ -7,7 +7,7 @@
 
 * Notes
 
-Emacs 30 installed from d12frosted/homebrew-emacs-plus
+Emacs 30 installed from [[https://github.com/d12frosted/homebrew-emacs-plus][homebrew-emacs-plus]]
 
 Otherwise blank =emacs -Q=
 

--- a/cpu/apple-m4.org
+++ b/cpu/apple-m4.org
@@ -1,0 +1,80 @@
+* Spec
+
+- CPU: Apple M4
+- OS: macOS Sequoia 15.5
+- Emacs: 30.1
+- Benchmarks: 1.16
+
+* Notes
+
+Emacs 30 installed from d12frosted/homebrew-emacs-plus
+
+Otherwise blank =emacs -Q=
+
+For better comparability I include both the results with my usual 8MB gc-cons-threshold and without
+
+* Results
+
+#+begin_src elisp
+(setq gc-cons-threshold (* 8 1024 1024))
+#+end_src
+
+  | test               | non-gc avg (s) | gc avg (s) | gcs avg | tot avg (s) | tot avg err (s) |
+  |--------------------+----------------+------------+---------+-------------+-----------------|
+  | bubble             |           0.26 |       0.06 |       1 |        0.33 |            0.01 |
+  | bubble-no-cons     |           0.36 |       0.00 |       0 |        0.36 |            0.00 |
+  | bytecomp           |           0.50 |       0.21 |      14 |        0.71 |            0.01 |
+  | dhrystone          |           0.74 |       0.00 |       0 |        0.74 |            0.01 |
+  | eieio              |           0.48 |       0.23 |      18 |        0.72 |            0.01 |
+  | fibn               |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | fibn-named-let     |           0.57 |       0.00 |       0 |        0.57 |            0.00 |
+  | fibn-rec           |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | fibn-tc            |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | flet               |           0.52 |       0.00 |       0 |        0.52 |            0.01 |
+  | font-lock          |           0.30 |       0.04 |       3 |        0.34 |            0.01 |
+  | inclist            |           0.75 |       0.00 |       0 |        0.75 |            0.01 |
+  | inclist-type-hints |           0.68 |       0.00 |       0 |        0.68 |            0.00 |
+  | listlen-tc         |           0.07 |       0.00 |       0 |        0.07 |            0.00 |
+  | map-closure        |           2.68 |       0.00 |       0 |        2.68 |            0.02 |
+  | nbody              |           0.74 |       0.16 |       1 |        0.90 |            0.02 |
+  | pack-unpack        |           0.15 |       0.05 |       4 |        0.20 |            0.00 |
+  | pack-unpack-old    |           0.20 |       0.10 |       8 |        0.30 |            0.00 |
+  | pcase              |           1.22 |       0.00 |       0 |        1.22 |            0.01 |
+  | pidigits           |           1.85 |       1.46 |      43 |        3.31 |            0.02 |
+  | scroll             |           0.86 |       0.05 |       3 |        0.91 |            0.03 |
+  | smie               |           0.62 |       0.07 |       5 |        0.70 |            0.00 |
+  |--------------------+----------------+------------+---------+-------------+-----------------|
+  | total              |          13.57 |       2.44 |     100 |       16.01 |            0.05 |
+
+* Results with default =gc-cons-threshold=
+
+#+begin_src elisp
+(setq gc-cons-threshold 800000)
+#+end_src
+
+  | test               | non-gc avg (s) | gc avg (s) | gcs avg | tot avg (s) | tot avg err (s) |
+  |--------------------+----------------+------------+---------+-------------+-----------------|
+  | bubble             |           0.26 |       0.06 |       1 |        0.32 |            0.01 |
+  | bubble-no-cons     |           0.36 |       0.01 |       1 |        0.37 |            0.01 |
+  | bytecomp           |           0.49 |       0.86 |      91 |        1.35 |            0.02 |
+  | dhrystone          |           0.91 |       0.00 |       0 |        0.91 |            0.01 |
+  | eieio              |           0.49 |       1.07 |     117 |        1.55 |            0.01 |
+  | fibn               |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | fibn-named-let     |           0.57 |       0.00 |       0 |        0.57 |            0.00 |
+  | fibn-rec           |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | fibn-tc            |           0.00 |       0.00 |       0 |        0.00 |            0.00 |
+  | flet               |           0.54 |       0.00 |       0 |        0.54 |            0.01 |
+  | font-lock          |           0.30 |       0.20 |      21 |        0.50 |            0.00 |
+  | inclist            |           0.66 |       0.00 |       0 |        0.66 |            0.01 |
+  | inclist-type-hints |           0.59 |       0.00 |       0 |        0.59 |            0.00 |
+  | listlen-tc         |           0.07 |       0.00 |       0 |        0.07 |            0.00 |
+  | map-closure        |           2.71 |       0.00 |       0 |        2.71 |            0.02 |
+  | nbody              |           0.74 |       0.15 |       1 |        0.90 |            0.01 |
+  | pack-unpack        |           0.15 |       0.28 |      30 |        0.42 |            0.00 |
+  | pack-unpack-old    |           0.20 |       0.52 |      57 |        0.72 |            0.01 |
+  | pcase              |           1.23 |       0.00 |       0 |        1.23 |            0.00 |
+  | pidigits           |           1.82 |       3.39 |     283 |        5.20 |            0.02 |
+  | scroll             |           0.87 |       0.21 |      20 |        1.08 |            0.03 |
+  | smie               |           0.63 |       0.31 |      33 |        0.94 |            0.00 |
+  |--------------------+----------------+------------+---------+-------------+-----------------|
+  | total              |          13.60 |       7.06 |     657 |       20.65 |            0.05 |


### PR DESCRIPTION
I could steal top spot by completely disabling gc, but I wouldn't want to overshadow the impressive customizations made by @LemonBreezes in his Ryzen 7950X benchmark.