### PR TITLE
Added AMD Ryzen 7 5700G high score to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a repo of elisp-benchmarks with native compilation run on different CPUs
 
 We had to reset the high scores and exclude all scores that didn't use accurate Emacs settings (now documented below), so the below list may seem unusual if you are just looking at scores.
 
+1. AMD Ryzen 7 5700G: 31.21s
 1. AMD Ryzen 9800X3D: 32.35s
 2. Intel Core i5-7500T: 53.48s
 3. AMD Ryzen 5700U: 54.94s


### PR DESCRIPTION
Added AMD Ryzen 7 5700G high score to the list.